### PR TITLE
Fix "Object argument required." error

### DIFF
--- a/create-base-path-mapping-service.js
+++ b/create-base-path-mapping-service.js
@@ -48,11 +48,10 @@ class CreateBasePathMappingService {
 					stage: this._config.stage
 				});
 			});
-
 	}
 
 	_getRestApiInfo() {
-		return this._provider.request("APIGateway", "getRestApis")
+		return this._provider.request("APIGateway", "getRestApis", {})
 			.then(apis => {
 				return apis.items.find(a => a.name === this._provider.naming.getApiGatewayName());
 			});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-base-path-mapping",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Creates a AWS base path mapping in custom domain name",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
There is a small breaking change in the serverless AWS provider api.
The `params` parameter in the request method is now required. This
happened after adding request cache -
https://github.com/serverless/serverless/pull/4518
The solution is to pass empty object to the request method when we try
to get the rest apis.

Fixes https://github.com/TsvetanMilanov/serverless-base-path-mapping/issues/2